### PR TITLE
Timer Functions and Bug fixes

### DIFF
--- a/source/Tools/nandDump.hpp
+++ b/source/Tools/nandDump.hpp
@@ -35,8 +35,9 @@
 #include "../UI.hpp"
 
 #define MAX_SIZE 0xBA600000
-#define BLOCK_SIZE 0x100000
-
+#define NAND_BLOCK_SIZE 0x470000
+#define CAL0_BLOCK_SIZE 0x3FBC00
+#define BOOT_BLOCK_SIZE 0x400000
 using namespace std;
 
 enum partitions {
@@ -49,7 +50,7 @@ enum partitions {
     BCPKG24,
     BCPKG25,
     BCPKG26,
-    ProdInfo,
+    ProdInfo = 27,
     ProdInfoF,
     SAFE,
     USER,

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -20,6 +20,7 @@
 #include "Net/Request.hpp"
 #include "Tools/autorcm.hpp"
 #include "Tools/kipmanager.hpp"
+#include "Tools/nandDump.hpp"
 #include "Utils/unzip_utils.hpp"
 #include "FS.hpp"
 #include "UI.hpp"
@@ -111,9 +112,9 @@ void UI::optAutoRCM() {
 }
 
 void UI::optDumpCal0() {
-    if(Tools::CheckFreeSpace() >= (u64)BLOCK_SIZE*4) {
+    if(Tools::CheckFreeSpace() >= CAL0_BLOCK_SIZE) {
         appletBeginBlockingHomeButton(0);
-        Tools::DumpPartition(27, "cal0.bin");
+        Tools::DumpPartition(ProdInfo, "cal0.bin");
         appletEndBlockingHomeButton();
     } else {
         MessageBox("Warning!", "Not enough space on the SD card to write to!", TYPE_OK);
@@ -121,10 +122,10 @@ void UI::optDumpCal0() {
 }
 
 void UI::optDumpBoots() {
-    if(Tools::CheckFreeSpace() >= ((u64)BLOCK_SIZE*8)) {
+    if(Tools::CheckFreeSpace() >= BOOT_BLOCK_SIZE*2) {
         appletBeginBlockingHomeButton(0);
-        Tools::DumpPartition(0, "boot0.bin");
-        Tools::DumpPartition(10, "boot1.bin");
+        Tools::DumpPartition(boot0, "boot0.bin");
+        Tools::DumpPartition(boot1, "boot1.bin");
         appletEndBlockingHomeButton();
     } else {
         MessageBox("Warning!", "Not enough space on the SD card to write to!", TYPE_OK);
@@ -134,7 +135,7 @@ void UI::optDumpBoots() {
 void UI::optDumpNand() {
     if(Tools::CheckFreeSpace() >= (u64)MAX_SIZE) {
         appletBeginBlockingHomeButton(0);
-        Tools::DumpPartition(20, "nand.bin");
+        Tools::DumpPartition(rawnand, "nand.bin");
         appletEndBlockingHomeButton();
     } else {
         MessageBox("Warning!", "Not enough space on the SD card to write to!", TYPE_OK);


### PR DESCRIPTION
Reimplemented timer functions
reworked UI.cpp to pull from enum Partitions rather than passing part_number directly
Used different buffer sizes for the types of dumps in increase dumping speed overall (only noticible on full dump and is about 5-7 minutes faster now)
General bug fixes