### PR TITLE
You wont need this anymore

### DIFF
--- a/source/Utils/utils.c
+++ b/source/Utils/utils.c
@@ -11,9 +11,6 @@
 #include "sha256.h"
 
 void gfx_update(void) {
-  gfxFlushBuffers();
-  gfxSwapBuffers();
-  gfxWaitForVsync();
 }
 
 void wait_for_button(u64 b) {


### PR DESCRIPTION
now you can compile with libnx 2.0.

Co-Authored-By: RetroGamer74
