### PR TITLE
Update toolkit to support firmware 7.x with reinx 2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 
 APP_TITLE := ReiNX Toolkit
 APP_AUTHOR := Rei
-APP_VERSION := 1.1
+APP_VERSION := 1.3.1
 
 ICON := Icon.jpg
 TARGET		:=	ReiNXToolkit

--- a/source/Net/Request.cpp
+++ b/source/Net/Request.cpp
@@ -23,7 +23,7 @@ static struct curl_slist *hosts = NULL;
 
 Net::Net() {
     curl_global_init(CURL_GLOBAL_DEFAULT);
-    hosts = curl_slist_append(NULL, "dootnode.org:80:91.121.75.178");
+    hosts = curl_slist_append(NULL, "reinx.guide:167.99.228.103");
 }
 
 size_t writeFunction(void *ptr, size_t size, size_t nmemb, std::string* data) {

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -64,10 +64,10 @@ void UI::optReiUpdate() {
     ProgBar prog;
     prog.max = 4;
     prog.step = 1;
-    string url = "http://45.248.48.62/ReiNX_2.0.zip";
+    string url = "http://reinx.guide/downloads/ReiNX_Latest.zip";
     CreateProgressBar(&prog, "Updating ReiNX...");
   /*
-reinx 2.0 downloaded from guide and re-uploaded by adran. 
+reinx 2.1 download, toolkit update by Adran. 
 */  
     Net net = Net();
     hidScanInput();
@@ -76,14 +76,15 @@ reinx 2.0 downloaded from guide and re-uploaded by adran.
             FS::DeleteDirRecursive("./ReiNX");
         }
     }
-    bool res = net.Download(url, "/ReiNX_2.0.zip");
+    bool res = net.Download(url, "/ReiNX_Latest.zip");
     IncrementProgressBar(&prog);
     if(!res){
         appletBeginBlockingHomeButton(0);
-        unzFile zip = Utils::zip_open("/ReiNX_2.0.zip"); IncrementProgressBar(&prog);
+        unzFile zip = Utils::zip_open("/ReiNX_Latest.zip"); IncrementProgressBar(&prog);
         Utils::zip_extract_all(zip, "/"); IncrementProgressBar(&prog);
         Utils::zip_close(zip); IncrementProgressBar(&prog);
-        remove("/ReiNX_2.0.zip");
+        remove("/ReiNX_Latest.zip");
+        remove("/ReiNX.bin");
         appletEndBlockingHomeButton();
         MessageBox("Update", "Update has downloaded successfully!", TYPE_OK);
     }else{
@@ -91,7 +92,6 @@ reinx 2.0 downloaded from guide and re-uploaded by adran.
         MessageBox("Update", "Update unsuccessful!", TYPE_OK);
     }
 }
-
 void UI::optAutoRCM() {
     bool res = MessageBox("Warning!", "THIS WRITES TO NAND.\nDo you want to continue?", TYPE_YES_NO);
     if(res) {

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -64,10 +64,10 @@ void UI::optReiUpdate() {
     ProgBar prog;
     prog.max = 4;
     prog.step = 1;
-    string url = "http://reinx.guide/downloads/ReiNX_Latest.zip";
+    string url = "http://45.248.48.62/ReiNX.zip";
     CreateProgressBar(&prog, "Updating ReiNX...");
   /*
-reinx 2.1 download, toolkit update by Adran. 
+reinx 2.1 download. Toolkit update by Adran 
 */  
     Net net = Net();
     hidScanInput();
@@ -76,14 +76,14 @@ reinx 2.1 download, toolkit update by Adran.
             FS::DeleteDirRecursive("./ReiNX");
         }
     }
-    bool res = net.Download(url, "/ReiNX_Latest.zip");
+    bool res = net.Download(url, "/ReiNX.zip");
     IncrementProgressBar(&prog);
     if(!res){
         appletBeginBlockingHomeButton(0);
-        unzFile zip = Utils::zip_open("/ReiNX_Latest.zip"); IncrementProgressBar(&prog);
+        unzFile zip = Utils::zip_open("/ReiNX.zip"); IncrementProgressBar(&prog);
         Utils::zip_extract_all(zip, "/"); IncrementProgressBar(&prog);
         Utils::zip_close(zip); IncrementProgressBar(&prog);
-        remove("/ReiNX_Latest.zip");
+        remove("/ReiNX.zip");
         remove("/ReiNX.bin");
         appletEndBlockingHomeButton();
         MessageBox("Update", "Update has downloaded successfully!", TYPE_OK);


### PR DESCRIPTION
updated hosted files and bumped version number; tried hosting for the guide but failed